### PR TITLE
codi: convert codi to wsgi application served with gunicorn

### DIFF
--- a/codi/codi.py
+++ b/codi/codi.py
@@ -133,15 +133,3 @@ class Codi() :
             return "Success"
         else:
             return "Error"
-
-    def get_arg_parser(self):
-        '''Create CODI command line argument parser
-        returns: codi arguments
-        '''
-        parser = argparse.ArgumentParser(
-                description='CODI command line arguments')
-        parser.add_argument('--ip', default="0.0.0.0",
-                help='codi ip address (default: 0.0.0.0)')
-        parser.add_argument('--port', default=10000, type=int,
-                help='codi port (default: 10000)')
-        return parser.parse_args()

--- a/launchers/codi-launcher.py
+++ b/launchers/codi-launcher.py
@@ -28,10 +28,7 @@ def register_codi_routes (app):
     app.add_url_rule('/codi/remove-image', 'remove-image', codi.remove_image)
     app.add_url_rule('/codi/remove-toolchain', 'remove_toolchain', codi.remove_toolchain)
 
-if __name__ == '__main__':
-    app = Flask(__name__)
-    db = codiDB.CodiDB(config.CODI_DB)
-    codi = codi.Codi(app, db)
-    register_codi_routes(app)
-    codi_args = codi.get_arg_parser()
-    app.run(host=codi_args.ip, port=codi_args.port, debug=True)
+app = Flask(__name__)
+db = codiDB.CodiDB(config.CODI_DB)
+codi = codi.Codi(app, db)
+register_codi_routes(app)


### PR DESCRIPTION
The flask server is blocking and synchronous and we need to
be able to handle multiple simultaneous toolchain
registrations asynchronously. Gunicorn is used as a WSGI server to spawn
multiple flask application workers.

Example: Spawn 4 workers listening on 0.0.0.0:10000

gunicorn -w 4 -b 0.0.0.0:10000 codi-launcher:app

Signed-off-by: Todor Minchev <todor.minchev@linux.intel.com>